### PR TITLE
団体名を「関西春ロボコン運営委員会」に変更 #3

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -101,7 +101,7 @@ canonifyURLs = true
 
     logo = "img/harurobo_logo.png"
     logo_small = "img/harurobo_logo.png"
-    address = """<p><strong>関西春ロボコン事務局</strong>
+    address = """<p><strong>関西春ロボコン運営委員会</strong>
         <br>
       </p>
       """

--- a/content/contact.md
+++ b/content/contact.md
@@ -8,4 +8,4 @@ banner = ""
 エントリーシート、FAQの提出、または運営面に関する質問は以下のメールアドレスへお問い合わせください。
 
 
-{{< figure src="/img/gmail.png" title="関西春ロボコン事務局" >}}
+{{< figure src="/img/gmail.png" title="関西春ロボコン運営委員会" >}}


### PR DESCRIPTION
目につくところは修正しました。

close #3 